### PR TITLE
Remove `causal_conv1d` req in mamba setup.py.

### DIFF
--- a/mamba-1p1p1/setup.py
+++ b/mamba-1p1p1/setup.py
@@ -271,6 +271,6 @@ setup(
         "einops",
         "triton",
         "transformers",
-        "causal_conv1d>=1.1.0",
+        # "causal_conv1d>=1.1.0",
     ],
 )


### PR DESCRIPTION
(Tiny fix)

I had trouble running the example notebook according to the environment setup instructions.

Turns out the `mamba-1p1p1/setup.py` had a dependency on `causal_conv1d>=1.1.0` that overwrote the editable install. 